### PR TITLE
Corrections du Sprint 1 sur le serveur

### DIFF
--- a/api/controlleurs/AdminControlleur.class.php
+++ b/api/controlleurs/AdminControlleur.class.php
@@ -41,7 +41,7 @@ class AdminControlleur extends Controlleur
                 $oVue->affichePied(); 
 
             }else{
-                header("location:http://localhost/art-public-mtl/api/admin/menu");
+                header("location:/art-public-mtl/api/admin/menu");
             }
 
 		}
@@ -101,7 +101,7 @@ class AdminControlleur extends Controlleur
                 $_SESSION['login'] = $_POST['login'];
                 
                 //redirection vers le menu admin
-                header("location:http://localhost/art-public-mtl/api/admin/menu");
+                header("location:/art-public-mtl/api/admin/menu");
 			}
 			else //connexion non reconnue
 			{
@@ -112,7 +112,7 @@ class AdminControlleur extends Controlleur
 //                apc_store($apc_blocked_key, $blocked+1, 86400);
                 
                 session_destroy(); //détruire la session
-                header("location:http://localhost/art-public-mtl/api/admin"); //redirige vers l'accueil (login)
+                header("location:/art-public-mtl/api/admin"); //redirige vers l'accueil (login)
                 exit();
             }
           

--- a/api/controlleurs/MenuAdminControlleur.class.php
+++ b/api/controlleurs/MenuAdminControlleur.class.php
@@ -32,7 +32,7 @@ class MenuAdminControlleur extends Controlleur
         //redirige vers l'accueil si admin pas connecté.
         else
         {
-            header("location:http://localhost/art-public-mtl/api/admin");
+            header("location:/art-public-mtl/api/admin");
             exit();
         }
     }
@@ -52,7 +52,7 @@ class MenuAdminControlleur extends Controlleur
             // si action deconnexion alors detruire la session et rediriger
             session_start();
             session_destroy(); //détruit la session
-            header("location:http://localhost/art-public-mtl/api/admin"); //retourne à l'accueil admin (vue de connexion)
+            header("location:/art-public-mtl/api/admin"); //retourne à l'accueil admin (vue de connexion)
             exit();
         }
         //si l'action n'est pas une des actions définies précédemment

--- a/api/controlleurs/OeuvreAdminControlleur.class.php
+++ b/api/controlleurs/OeuvreAdminControlleur.class.php
@@ -67,7 +67,7 @@ class OeuvreAdminControlleur extends OeuvreControlleur
         {
             $id=$requete->url_elements[1];
             $res = $this->SupprimerOeuvre($id);
-            header("location:http://localhost/art-public-mtl/api/admin/oeuvre");
+            header("location:/art-public-mtl/api/admin/oeuvre");
             exit();
         }
 			else if(isset($requete->url_elements[1]) && $requete->url_elements[1] == "oeuvre")
@@ -109,7 +109,7 @@ class OeuvreAdminControlleur extends OeuvreControlleur
 		else
         {
             //si l'admin n'est pas connecté, rediriger vers l'accueil (login)
-            header("location:http://localhost/art-public-mtl/api/admin");
+            header("location:/art-public-mtl/api/admin");
 			exit();
 		}
 	}

--- a/api/vues/admin/MenuAdmin.html.php
+++ b/api/vues/admin/MenuAdmin.html.php
@@ -25,6 +25,4 @@
 						<a href="">Supprimer</a>
 				</fieldset>
 			</div>
-		</section>    
-			
-		<?php
+		</section>


### PR DESCRIPTION
Il faut faire ces changements parce que le http://localhost ne fonctionne pas dans le serveur. En fait, il n'est pas non plus nécessaire sur votre serveur local.

 Dans le cas du api/vues/admin/MenuAdmin.html.php, il faut faire attention aux balises php non fermées, parce que le serveur est moins permissif que le local.